### PR TITLE
declare wider range of supported Angular versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
 	},
 	"homepage": "https://github.com/gforceg/ng2-font-awesome#readme",
 	"peerDependencies": {
-		"@angular/common": "^4.0.0",
-		"@angular/core": "^4.0.0",
+		"@angular/common": ">=4 <6",
+		"@angular/core": ">=4 <6",
 		"rxjs": "^5.0.1",
 		"zone.js": "^0.8.4"
 	},
 	"devDependencies": {
-		"@angular/common": "^4.0.0",
-		"@angular/compiler": "^4.0.0",
-		"@angular/compiler-cli": "^4.0.0",
-		"@angular/core": "^4.0.0",
+		"@angular/common": ">=4 <6",
+		"@angular/compiler": ">=4 <6",
+		"@angular/compiler-cli": ">=4 <6",
+		"@angular/core": ">=4 <6",
 		"del": "^2.2.2",
 		"gulp": "^3.9.1",
 		"gulp-clean": "^0.3.2",


### PR DESCRIPTION
removes warnings:
npm WARN ng2-font-awesome@1.0.31 requires a peer of @angular/common@^4.0.0 but none was installed.
npm WARN ng2-font-awesome@1.0.31 requires a peer of @angular/core@^4.0.0 but none was installed.